### PR TITLE
Update ContactDelegate.qml

### DIFF
--- a/src/imports/Ubuntu/Contacts/ContactDelegate.qml
+++ b/src/imports/Ubuntu/Contacts/ContactDelegate.qml
@@ -76,7 +76,7 @@ ListItemWithActions {
                 verticalCenter: parent.verticalCenter
                 right: parent.right
             }
-            color: selected ? UbuntuColors.blue : UbuntuColors.darkGrey
+            color: selected ? theme.palette.normal.activity : theme.palette.normal.backgroundText
             text: root.displayLabel != "" ? root.displayLabel : i18n.dtr("address-book-app", "No name")
             elide: Text.ElideRight
         }


### PR DESCRIPTION
Used theme palettes instead of UbuntuColors.
This is also for the Night Mode support of messaging-app since hardcoding "darkGrey" is not good.

Note that this will also change the text color in the default theme although I'd say it's more readable this way.