### PR TITLE
ContactEditorPage: don't show "Edit" title when adding a contact

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-address-book-app (0.3+ubports1) UNRELEASED; urgency=medium
+address-book-app (0.4~0ubports1) xenial; urgency=medium
 
-  * No change rebuild to generate sources in ubports repo
+  * Don't show the 'Edit' page when adding a new contact.
 
- -- Dan Chapman <dan@ubports.com>  Tue, 20 Feb 2018 07:30:25 +0000
+ -- Alberto Mardegan <mardy@users.sourceforge.net>  Fri, 14 Sep 2018 00:17:29 +0300
 
 address-book-app (0.3+ubports) xenial; urgency=medium
 

--- a/src/imports/Ubuntu/AddressBook/ContactEditor/ContactEditorPage.qml
+++ b/src/imports/Ubuntu/AddressBook/ContactEditor/ContactEditorPage.qml
@@ -36,7 +36,7 @@ Page {
     property list<QtObject> leadingActions
     property alias headerActions: trailingBar.actions
 
-    readonly property bool isNewContact: contact && (contact.contactId === "qtcontacts:::")
+    readonly property bool isNewContact: contact && (!contact.contactId || contact.contactId === "qtcontacts:::")
     readonly property bool isContactValid: !avatarEditor.busy && (!nameEditor.isEmpty() || !phonesEditor.isEmpty())
     readonly property alias editorFlickable: scrollArea
 


### PR DESCRIPTION
The test for whether a contact is a new one is different, with the
latest QtPim.

Part of ubports/ubuntu-touch#878