### PR TITLE
improve FastScroll to work also with single tap on touchscreens

### DIFF
--- a/src/imports/Ubuntu/Contacts/FastScroll.qml
+++ b/src/imports/Ubuntu/Contacts/FastScroll.qml
@@ -216,26 +216,15 @@ Item {
         preventStealing: true
         onPressed: {
             internal.adjustContentPosition(mouseY)
-            dragginTimer.start()
+            internal.fastScrolling = true
         }
 
         onReleased: {
-            dragginTimer.stop()
-            internal.desireSection = ""
             internal.fastScrolling = false
         }
 
         onPositionChanged: internal.adjustContentPosition(mouseY)
 
-        Timer {
-            id: dragginTimer
-
-            running: false
-            interval: 150
-            onTriggered: {
-                internal.fastScrolling = true
-            }
-        }
     }
 
     Timer {
@@ -327,4 +316,3 @@ Item {
         }
     }
 }
-


### PR DESCRIPTION
tapping on the `FastScroll` letter list doesn't work atm on touchscreens, you have to drag or keep pressed for at least 150ms.

I fixed this on [teleports](https://gitlab.com/ubports/apps/teleports/-/merge_requests/268) too, and I haven't seen any regression yet