### PR TITLE
Remove unused Q_SLOT

### DIFF
--- a/src/imports/Ubuntu/Contacts/simcardcontacts.h
+++ b/src/imports/Ubuntu/Contacts/simcardcontacts.h
@@ -49,7 +49,6 @@ Q_SIGNALS:
     void busyChanged();
 
 private Q_SLOTS:
-    void onModemChanged();
     void onPhoneBookIsValidChanged(bool isValid);
     void onPhoneBookImported(const QString &vcardData);
     void onPhoneBookImportFail();


### PR DESCRIPTION
This causes never qt to complain about missing symbols, and its defined anywhere or used anywhere, so remove it.