### PR TITLE
debian/control: depend on address-book-updater

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,6 +42,7 @@ X-Ubuntu-Use-Langpack: yes
 Package: address-book-app
 Architecture: any
 Depends:
+ address-book-updater,
  libqt5contacts5,
  libqt5versit5,
  qml-module-ofono,


### PR DESCRIPTION
`address-book-updater` is currently brought in the image via
`ubuntu-touch-meta`. However, address-book-updater is specific to the
QtContacts backend currently used, which will be replaced by the
SailfishOS one.

So, once we'll get the new SailfishOS contacts backend, we'll have to
remove the `address-book-updater`, and it's more easily done if it's
listed as a dependency in a normal package (so that ubports-qa will be
able to affect it).

The next step is to remove the `address-book-updater` from
`ubuntu-touch-meta`.

Contributes to ubports/ubuntu-touch#997